### PR TITLE
Chop the protocol and hostport information off absolute URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,5 @@
 All notable changes to this project will be documented in this file.
 This project follows [Semantic Versioning](http://semver.org/).
 
-## [0.1.0] - 2018-11-10
- - Support Meteor 1.8
- - BREAKING CHANGE - Meteor 1.7 and lower are no longer supported, use version 0.0.3
-
-## [0.0.3] - 2018-11-10
- - Add gif files to default extensions
-
-## [0.0.2] - 2018-01-25
- - Support static assets inside of meteor packages
-
-## [0.0.1] - 2018-01-24
- - Initial release
+## [0.1.0] - 2024-05-29
+- Forked from `nathantreid:static-assets`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,8 @@
 All notable changes to this project will be documented in this file.
 This project follows [Semantic Versioning](http://semver.org/).
 
+## [0.1.1] - 2024-05-29
+- Minor documentation update
+
 ## [0.1.0] - 2024-05-29
 - Forked from `nathantreid:static-assets`

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
 The MIT License (MIT)
+Copyright © 2024 EPFL
 Copyright © 2018 Nathan Reid
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Static Assets Compiler for Meteor
 1. Install the package
 
 ```bash
-meteor add nathantreid:static-assets
+meteor add epfl:static-assets
 ```
 
 ## Usage

--- a/compiler.js
+++ b/compiler.js
@@ -34,7 +34,7 @@ export default class AssetsCompiler extends CachingCompiler {
     const appRelativeHostingPath = inputFile.getPackageName() ? `packages/${inputFile.getPackageName().replace(':', '_')}/${packageRelativeHostingPath}` : packageRelativeHostingPath;
     let exportCode;
     exportCode = packageOptions.exportAbsolutePaths
-      ? `module.exports = require('meteor/meteor').Meteor.absoluteUrl('${appRelativeHostingPath}');`
+      ? `module.exports = require('meteor/meteor').Meteor.absoluteUrl('${appRelativeHostingPath}').replace(new RegExp('^.*//.*?/'), '/');`
       : `module.exports = '${appRelativeHostingPath}';`;
 
     inputFile.addJavaScript({

--- a/options.js
+++ b/options.js
@@ -3,7 +3,7 @@ import meteorProjectPath from 'meteor-project-path';
 import path from 'path';
 import sha1 from './sha1';
 
-global.nathantreidStaticAssets = global.nathantreidStaticAssets || { lastNotifiedHash: null, };
+global.epflStaticAssets = global.epflStaticAssets || { lastNotifiedHash: null, };
 const optionsFilePath = path.join(meteorProjectPath || '', 'package.json');
 
 const defaultOptions = {
@@ -29,12 +29,12 @@ function loadOptions() {
   options = { ...defaultOptions, ...userOptions };
   options.hash = sha1(JSON.stringify(options));
 
-  if (previousHash && previousHash !== options.hash && global.nathantreidStaticAssets.lastNotifiedHash !== options.hash) {
-    global.nathantreidStaticAssets.lastNotifiedHash = options.hash;
-    console.info('nathantreid:static-assets plugin options updated, recompiling all static assets.');
+  if (previousHash && previousHash !== options.hash && global.epflStaticAssets.lastNotifiedHash !== options.hash) {
+    global.epflStaticAssets.lastNotifiedHash = options.hash;
+    console.info('epfl:static-assets plugin options updated, recompiling all static assets.');
 
     if (JSON.stringify(options.extensions) !== initialExtensions) {
-      console.warn(`The list of extensions handled by the nathantreid:static-assets plugin has changed to: ${options.extensions}.\nThis change requires a manual Meteor restart to take effect.\n`)
+      console.warn(`The list of extensions handled by the epfl:static-assets plugin has changed to: ${options.extensions}.\nThis change requires a manual Meteor restart to take effect.\n`)
     }
   }
 }

--- a/package.js
+++ b/package.js
@@ -1,9 +1,9 @@
 Package.describe({
-  name: 'nathantreid:static-assets',
+  name: 'epfl:static-assets',
   version: '0.1.0',
   summary: 'Import any static assets you like!',
   documentation: 'README.md',
-  git: 'https://github.com/nathantreid/meteor-static-assets.git',
+  git: 'https://github.com/epfl-si/meteor-static-assets.git',
 });
 
 Package.registerBuildPlugin({

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'epfl:static-assets',
-  version: '0.1.0',
+  version: '0.1.1',
   summary: 'Import any static assets you like!',
   documentation: 'README.md',
   git: 'https://github.com/epfl-si/meteor-static-assets.git',

--- a/package.js
+++ b/package.js
@@ -9,7 +9,7 @@ Package.describe({
 Package.registerBuildPlugin({
   name: 'static-assets',
   use: [
-    'caching-compiler@1.2.0',
+    'caching-compiler@2.0.0-alpha300.17',
     'ecmascript@0.12.0',
   ],
   sources: [


### PR DESCRIPTION
The `http://localhost:3000/` part in e.g. `http://localhost:3000/static/client/my/logo.svg` tends to not work in very simple cases, such as
when accessing your development Meteor app through its IP address or
host name (e.g. `http://1.2.3.4:3000/`). Just chop it off, and trust the
browser to resolve e.g. `/static/client/my/logo.svg` relative to
whatever protocol, host and port the Meteor app was loaded from in the
first place.

I am not aware of any case where we would be worse off by doing this.
